### PR TITLE
Fix: count down modal close time after image and message are ready

### DIFF
--- a/src/Board/Dialog/Dialog.tsx
+++ b/src/Board/Dialog/Dialog.tsx
@@ -1,19 +1,22 @@
 import React, { useState, useEffect } from 'react';
 import { preloadImageAsync } from '../../images/preloadImage';
+import { sleep } from '../../utils/sleep';
 import './dialog.scss';
 
 interface Props {
-  user: WeddiApp.Post.UserInput;
+  post: WeddiApp.Post.UserInput;
   show: boolean;
+  onReady?: () => void;
 }
 
-const Dialog: React.FC<Props> = ({ user, show }) => {
+const Dialog: React.FC<Props> = ({ post: user, show, onReady }) => {
   const [loaded, setLoaded] = useState(false);
   const [imageDimension, setImageDimension] = useState({ width: 0, height: 0 });
 
   useEffect(() => {
     // while image url changes set to loading
     if (user.imgUrl) {
+      setLoaded(false);
       preloadImageAsync(user.imgUrl).then((img) => {
         setLoaded(true);
         setImageDimension({ width: img.width, height: img.height });
@@ -21,8 +24,19 @@ const Dialog: React.FC<Props> = ({ user, show }) => {
     }
   }, [user.imgUrl]);
 
+  // while image is loaded and message moved to the position then fire onReady
+  useEffect(() => {
+    if (loaded) {
+      // wait 1s for message to move in
+      sleep(1000).then(() => {
+        if (typeof onReady === 'function') {
+          onReady();
+        }
+      });
+    }
+  }, [loaded, onReady]);
+
   const portraitImage = loaded && imageDimension.width < imageDimension.height;
-  console.log(imageDimension);
 
   return (
     <div className={`dialog ${(show && loaded) ? 'show-dialog' : ''}`}>

--- a/src/Greeting/Greeting.tsx
+++ b/src/Greeting/Greeting.tsx
@@ -39,7 +39,7 @@ export const Greeting: React.FC<RouteComponentProps> = (props) => {
           <a className="link gray-font" href="mailto:contact@weddi.app">聯絡我們 contact@weddi.app</a>
         </>
       }
-      <Dialog user={user} show={modalDisplay} />
+      <Dialog post={user} show={modalDisplay} />
     </div>
   );
 };


### PR DESCRIPTION
- refactor(weddi.app): restyle dialog
- refactor(weddi.app): restyle dialog
- refactor(weddi.app): reuse preloadImageAsync in dialog
- refactor(weddi.app): move off dialog from board to a unique foler
- fix(weddi.app): close modal after dialog image and message ready
